### PR TITLE
3-in-a-row detection added

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -68,7 +68,6 @@ object Main extends IOApp.Simple:
       s match
         case "X" => X
         case "O" => O
-        case "E" => E
 
   extension (s: Cell)
     def isFinished(): Boolean =


### PR DESCRIPTION
Pending concerns:
- $x$ and $y$ variables may not be properly named (they might need to be $y$ and $x$, but I am not sure)
    - this can cause confusion down the line
- Finding matches will probably not work on non-square boards for similar reason